### PR TITLE
Prototype of displaying provider specific attributes

### DIFF
--- a/lib/hammer_cli_foreman/compute_profile.rb
+++ b/lib/hammer_cli_foreman/compute_profile.rb
@@ -1,9 +1,22 @@
 require 'hammer_cli_foreman/image'
+require 'hammer_cli_foreman/compute_resources/all'
 
 module HammerCLIForeman
 
   class ComputeProfile < HammerCLIForeman::Command
     resource :compute_profiles
+
+    def self.provider_attributes
+      @provider_attributes ||= {
+        'libvirt' => HammerCLIForeman::ComputeResources::Libvirt::ComputeAttributes.new,
+        'ec2' => HammerCLIForeman::ComputeResources::EC2::ComputeAttributes.new,
+        'default' => HammerCLIForeman::ComputeResources::Default::ComputeAttributes.new
+      }
+    end
+
+    def self.get_provider(name)
+      provider_attributes[name] || provider_attributes['default']
+    end
 
     class ListCommand < HammerCLIForeman::ListCommand
 
@@ -16,6 +29,15 @@ module HammerCLIForeman
     end
 
     class InfoCommand < HammerCLIForeman::InfoCommand
+      def self.vm_attrs_fields(dsl)
+        dsl.build do
+          HammerCLIForeman::ComputeProfile.provider_attributes.each do |k,t|
+            custom_field Fields::Label, :label => _("VM attributes"), :path => ["#{t.name}_vm_attrs".to_sym], :hide_blank => true do
+              t.fields(self)
+            end
+          end
+        end
+      end
 
       output ListCommand.output_definition do
 
@@ -26,8 +48,21 @@ module HammerCLIForeman
           field :id, _('Id')
           field :name, _('Name')
           field nil, _("Compute Resource"), Fields::SingleReference, :key => :compute_resource
-          field :vm_attrs, _("VM attributes")
+          field :provider_friendly_name, _('Provider type')
+          # field :vm_attrs, _("VM attributes original")
+
+          InfoCommand.vm_attrs_fields(self)
         end
+      end
+
+      def extend_data(record)
+        record['compute_attributes'].each do |attrs|
+          provider_name = attrs.fetch('provider_friendly_name', 'default')
+          transformer = HammerCLIForeman::ComputeProfile.get_provider(provider_name.downcase)
+          attrs[transformer.name + '_vm_attrs'] = transformer.transform_attributes(attrs['vm_attrs'])
+          attrs
+        end
+        record
       end
 
       build_options

--- a/lib/hammer_cli_foreman/compute_resources/all.rb
+++ b/lib/hammer_cli_foreman/compute_resources/all.rb
@@ -1,3 +1,4 @@
+require 'hammer_cli_foreman/compute_resources/default/compute_attributes'
 require 'hammer_cli_foreman/compute_resources/ec2'
 require 'hammer_cli_foreman/compute_resources/gce'
 require 'hammer_cli_foreman/compute_resources/libvirt'

--- a/lib/hammer_cli_foreman/compute_resources/compute_attributes_base.rb
+++ b/lib/hammer_cli_foreman/compute_resources/compute_attributes_base.rb
@@ -1,0 +1,17 @@
+module HammerCLIForeman
+  module ComputeResources
+    class ComputeAttributesBase
+      def name
+      end
+
+      def fields(dsl)
+      end
+
+      def transform_attributes(attrs)
+        attrs['nics_attributes'] = attrs['nics_attributes'].values if attrs.has_key?('nics_attributes')
+        attrs['volumes_attributes'] = attrs['volumes_attributes'].values if attrs.has_key?('volumes_attributes')
+        attrs
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/default/compute_attributes.rb
+++ b/lib/hammer_cli_foreman/compute_resources/default/compute_attributes.rb
@@ -1,0 +1,44 @@
+module HammerCLIForeman
+  module ComputeResources
+    module Default
+      class ComputeAttributes
+        def name
+          'default'
+        end
+
+        def fields(dsl)
+          dsl.build do
+            field :text_attributes, _('Attributes'), Fields::LongText
+            collection :nics_attributes, _("Network interfaces"), :hide_blank => true do
+              field :text_attributes, _('Attributes'), Fields::LongText
+            end
+            collection :volumes_attributes, _("Volumes"), :hide_blank => true do
+              field :text_attributes, _('Attributes'), Fields::LongText
+            end
+          end
+        end
+
+        def transform_attributes(attrs)
+          attrs['text_attributes'] = to_text(attrs.reject{ |k| ['nics_attributes', 'volumes_attributes'].include? k })
+          attrs['nics_attributes'] = add_text_attributes(attrs['nics_attributes'])
+          attrs['volumes_attributes'] = add_text_attributes(attrs['volumes_attributes'])
+          attrs
+        end
+
+        protected
+
+        def add_text_attributes(attribute_hash)
+          return unless attribute_hash
+          attribute_hash.values.map do |attr|
+            attr['text_attributes'] = to_text(attr)
+            attr
+          end
+        end
+
+        def to_text(data)
+          data.to_yaml.gsub(/^---$/, '').strip
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/ec2.rb
+++ b/lib/hammer_cli_foreman/compute_resources/ec2.rb
@@ -1,4 +1,5 @@
 require 'hammer_cli_foreman/compute_resources/ec2/host_help_extenstion'
+require 'hammer_cli_foreman/compute_resources/ec2/compute_attributes'
 
 module HammerCLIForeman
   module ComputeResources

--- a/lib/hammer_cli_foreman/compute_resources/ec2/compute_attributes.rb
+++ b/lib/hammer_cli_foreman/compute_resources/ec2/compute_attributes.rb
@@ -1,0 +1,22 @@
+require 'hammer_cli_foreman/compute_resources/compute_attributes_base'
+
+module HammerCLIForeman
+  module ComputeResources
+    module EC2
+      class ComputeAttributes < ComputeAttributesBase
+        def name
+          'ec2'
+        end
+
+        def fields(dsl)
+          dsl.build do
+            field :flavor_id, _('Flavor')
+            field :availability_zone, _('Zone')
+            field :managed_ip, _('Managed IP')
+            # TODO: add all attributes
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/hammer_cli_foreman/compute_resources/libvirt.rb
+++ b/lib/hammer_cli_foreman/compute_resources/libvirt.rb
@@ -1,4 +1,5 @@
 require 'hammer_cli_foreman/compute_resources/libvirt/host_help_extenstion'
+require 'hammer_cli_foreman/compute_resources/libvirt/compute_attributes'
 
 module HammerCLIForeman
   module ComputeResources

--- a/lib/hammer_cli_foreman/compute_resources/libvirt/compute_attributes.rb
+++ b/lib/hammer_cli_foreman/compute_resources/libvirt/compute_attributes.rb
@@ -1,0 +1,25 @@
+require 'hammer_cli_foreman/compute_resources/compute_attributes_base'
+
+module HammerCLIForeman
+  module ComputeResources
+    module Libvirt
+      class ComputeAttributes < ComputeAttributesBase
+        def name
+          'libvirt'
+        end
+
+        def fields(dsl)
+          dsl.build do
+            field :cpus, _('CPUs')
+            field :memory, _('Memory')
+            collection :nics_attributes, _("Network interfaces") do
+              field :type, _('Type')
+              field :bridge, _('Bridge')
+            end
+            # TODO: add all attributes
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- fields are defined by `ComputeAttribute` classes, that can also format the incoming data
- default is used when the attribute class is not available for a provider
- default is used also when foreman server doesn't reply with the provider name (older versions)
- default formats attributes as yaml

Please note that this change into core is necessary for this PR to work properly:
https://github.com/tstrachota/hammer-cli/commit/944f8f5544d73b0b3dd40298be29a03dc626b941
I still need to create an issue for that and open a PR against core.